### PR TITLE
Add reference to new paper

### DIFF
--- a/data/research-tracks.tsx
+++ b/data/research-tracks.tsx
@@ -101,6 +101,12 @@ export const researchTracksData: ResearchTrack[] = [
         type: 'paper',
       },
       {
+        title: 'Follow-up research on Hash-Based Multi-Signatures',
+        url: 'https://eprint.iacr.org/2025/889.pdf',
+        type: 'paper',
+      }
+      
+      {
         title: 'Towards Hash-Based Multi-Signatures for Post-Quantum Distributed Validators',
         url: 'https://github.com/ObolNetwork/pqdv/blob/main/doc/main.pdf',
         type: 'paper',

--- a/data/research-tracks.tsx
+++ b/data/research-tracks.tsx
@@ -104,8 +104,7 @@ export const researchTracksData: ResearchTrack[] = [
         title: 'Follow-up research on Hash-Based Multi-Signatures',
         url: 'https://eprint.iacr.org/2025/889.pdf',
         type: 'paper',
-      }
-      
+      },
       {
         title: 'Towards Hash-Based Multi-Signatures for Post-Quantum Distributed Validators',
         url: 'https://github.com/ObolNetwork/pqdv/blob/main/doc/main.pdf',


### PR DESCRIPTION
Follow-up paper on Hash-based multi-signatures, accepted at Crypto 2025.