### PR TITLE
Add 2025 ETHCC Beam Day Event Overview website

### DIFF
--- a/data/key-resources.tsx
+++ b/data/key-resources.tsx
@@ -50,4 +50,10 @@ export const keyResourcesData: KeyResource[] = [
     url: 'https://x.com/VitalikButerin/status/1885046277932552697',
     date: 'Jan 2025',
   },
+  {
+    icon: FileText,
+    title: 'Beam Day ETHCC 2025 Event Overview',
+    url: 'https://hackmd.io/@willcorcoran/BkZ-gs5Bll',
+    date: 'June 2025',
+   },
 ];


### PR DESCRIPTION
Added Will's excellent Hackmd summarizing beam day talks, with transcripts and slides.